### PR TITLE
feat: enhance pomodoro extension settings and debug interface

### DIFF
--- a/apps/browser-extension/locales/en/messages.json
+++ b/apps/browser-extension/locales/en/messages.json
@@ -234,5 +234,37 @@
   "languageJapanese": {
     "message": "日本語",
     "description": "Japanese language option"
+  },
+  "settingsTaskMode": {
+    "message": "Task Mode",
+    "description": "Task mode setting label"
+  },
+  "settingsTaskModeDesc": {
+    "message": "Enable task tracking during pomodoro sessions",
+    "description": "Task mode description"
+  },
+  "settingsFloatingTimer": {
+    "message": "Show Floating Timer",
+    "description": "Floating timer setting label"
+  },
+  "settingsFloatingTimerDesc": {
+    "message": "Display a floating timer overlay on web pages for better visibility",
+    "description": "Floating timer description"
+  },
+  "settingsBreakNotifications": {
+    "message": "Break Notifications",
+    "description": "Break notifications setting label"
+  },
+  "settingsBreakNotificationsDesc": {
+    "message": "Enable reminder notifications during break periods",
+    "description": "Break notifications description"
+  },
+  "settingsGeneralFeatures": {
+    "message": "General Features",
+    "description": "General features section title"
+  },
+  "settingsDisplayOptions": {
+    "message": "Display Options",
+    "description": "Display options section title"
   }
 }

--- a/apps/browser-extension/locales/ja/messages.json
+++ b/apps/browser-extension/locales/ja/messages.json
@@ -234,5 +234,37 @@
   "languageJapanese": {
     "message": "日本語",
     "description": "日本語言語オプション"
+  },
+  "settingsTaskMode": {
+    "message": "タスクモード",
+    "description": "タスクモード設定ラベル"
+  },
+  "settingsTaskModeDesc": {
+    "message": "ポモドーロセッション中にタスクトラッキングを有効にする",
+    "description": "タスクモードの説明"
+  },
+  "settingsFloatingTimer": {
+    "message": "フローティングタイマーを表示",
+    "description": "フローティングタイマー設定ラベル"
+  },
+  "settingsFloatingTimerDesc": {
+    "message": "ウェブページにフローティングタイマーオーバーレイを表示して見やすくする",
+    "description": "フローティングタイマーの説明"
+  },
+  "settingsBreakNotifications": {
+    "message": "休憩通知",
+    "description": "休憩通知設定ラベル"
+  },
+  "settingsBreakNotificationsDesc": {
+    "message": "休憩期間中にリマインダー通知を有効にする",
+    "description": "休憩通知の説明"
+  },
+  "settingsGeneralFeatures": {
+    "message": "一般機能",
+    "description": "一般機能セクションタイトル"
+  },
+  "settingsDisplayOptions": {
+    "message": "表示オプション",
+    "description": "表示オプションセクションタイトル"
   }
 }

--- a/apps/browser-extension/locales/zh/messages.json
+++ b/apps/browser-extension/locales/zh/messages.json
@@ -234,5 +234,37 @@
   "languageJapanese": {
     "message": "日本語",
     "description": "日语语言选项"
+  },
+  "settingsTaskMode": {
+    "message": "任务模式",
+    "description": "任务模式设置标签"
+  },
+  "settingsTaskModeDesc": {
+    "message": "在番茄钟期间启用任务跟踪功能",
+    "description": "任务模式描述"
+  },
+  "settingsFloatingTimer": {
+    "message": "显示浮动计时器",
+    "description": "浮动计时器设置标签"
+  },
+  "settingsFloatingTimerDesc": {
+    "message": "在网页上显示浮动计时器，提高可见性",
+    "description": "浮动计时器描述"
+  },
+  "settingsBreakNotifications": {
+    "message": "休息提醒",
+    "description": "休息通知设置标签"
+  },
+  "settingsBreakNotificationsDesc": {
+    "message": "在休息期间启用提醒通知",
+    "description": "休息通知描述"
+  },
+  "settingsGeneralFeatures": {
+    "message": "通用功能",
+    "description": "通用功能部分标题"
+  },
+  "settingsDisplayOptions": {
+    "message": "显示选项",
+    "description": "显示选项部分标题"
   }
 }

--- a/apps/browser-extension/src/components/pomodoro/PomodoroSettings.tsx
+++ b/apps/browser-extension/src/components/pomodoro/PomodoroSettings.tsx
@@ -10,16 +10,31 @@ import { Settings } from "lucide-react"
 interface PomodoroSettingsProps {
   isOpen?: boolean;
   onClose?: () => void;
+  showTaskSetting?: boolean;
 }
 
-export function PomodoroSettings({ isOpen = true, onClose }: PomodoroSettingsProps) {
+export function PomodoroSettings({ isOpen = true, onClose, showTaskSetting = true }: PomodoroSettingsProps) {
   const { state, updateConfig } = usePomodoro()
   const { t } = useI18n()
   const [strictMode, setStrictMode] = useState(state?.config?.strictMode ?? false)
+  const [enableTask, setEnableTask] = useState(state?.config?.enableTask ?? false)
+  const [showFloatingTimer, setShowFloatingTimer] = useState(state?.config?.showFloatingTimer ?? true)
+  const [enableBreakNotifications, setEnableBreakNotifications] = useState(state?.config?.enableBreakNotifications ?? true)
 
   useEffect(() => {
-    if (state?.config?.strictMode !== undefined) {
-      setStrictMode(state.config.strictMode)
+    if (state?.config) {
+      if (state.config.strictMode !== undefined) {
+        setStrictMode(state.config.strictMode)
+      }
+      if (state.config.enableTask !== undefined) {
+        setEnableTask(state.config.enableTask)
+      }
+      if (state.config.showFloatingTimer !== undefined) {
+        setShowFloatingTimer(state.config.showFloatingTimer)
+      }
+      if (state.config.enableBreakNotifications !== undefined) {
+        setEnableBreakNotifications(state.config.enableBreakNotifications)
+      }
     }
   }, [state?.config])
 
@@ -27,7 +42,10 @@ export function PomodoroSettings({ isOpen = true, onClose }: PomodoroSettingsPro
     if (!state?.config) return
     await updateConfig({
       ...state.config,
-      strictMode
+      strictMode,
+      enableTask,
+      showFloatingTimer,
+      enableBreakNotifications
     })
     onClose?.()
   }
@@ -47,7 +65,71 @@ export function PomodoroSettings({ isOpen = true, onClose }: PomodoroSettingsPro
       
       <Separator className="mb-4" />
       
-      <div className="flex-1">
+      <div className="flex-1 space-y-6">
+        {/* General Features Section */}
+        {showTaskSetting && (
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium">{t('settingsGeneralFeatures')}</h3>
+            
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1">
+                <Label htmlFor="enable-task" className="text-sm font-medium">
+                  {t('settingsTaskMode')}
+                </Label>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('settingsTaskModeDesc')}
+                </p>
+              </div>
+              <Switch
+                id="enable-task"
+                checked={enableTask}
+                onCheckedChange={setEnableTask}
+                aria-label={t('settingsTaskMode')}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Display Options Section */}
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium">{t('settingsDisplayOptions')}</h3>
+          
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1">
+              <Label htmlFor="floating-timer" className="text-sm font-medium">
+                {t('settingsFloatingTimer')}
+              </Label>
+              <p className="text-xs text-muted-foreground mt-1">
+                {t('settingsFloatingTimerDesc')}
+              </p>
+            </div>
+            <Switch
+              id="floating-timer"
+              checked={showFloatingTimer}
+              onCheckedChange={setShowFloatingTimer}
+              aria-label={t('settingsFloatingTimer')}
+            />
+          </div>
+
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1">
+              <Label htmlFor="break-notifications" className="text-sm font-medium">
+                {t('settingsBreakNotifications')}
+              </Label>
+              <p className="text-xs text-muted-foreground mt-1">
+                {t('settingsBreakNotificationsDesc')}
+              </p>
+            </div>
+            <Switch
+              id="break-notifications"
+              checked={enableBreakNotifications}
+              onCheckedChange={setEnableBreakNotifications}
+              aria-label={t('settingsBreakNotifications')}
+            />
+          </div>
+        </div>
+
+        {/* Break Behavior Section */}
         <div className="space-y-3">
           <h3 className="text-sm font-medium">{t('settingsBreakBehavior')}</h3>
           

--- a/apps/browser-extension/src/model/pomodoro/types.ts
+++ b/apps/browser-extension/src/model/pomodoro/types.ts
@@ -6,6 +6,9 @@ export type PomodoroConfig = {
   longMin: number; // minutes
   longEvery: number; // take long break after N focus sessions
   strictMode: boolean; // strict break mode (tab control)
+  enableTask: boolean; // enable task mode for pomodoro sessions
+  showFloatingTimer: boolean; // show floating timer in web pages
+  enableBreakNotifications: boolean; // enable break reminder notifications
 };
 
 export type PomodoroState = {
@@ -42,6 +45,9 @@ export const DEFAULT_CONFIG: PomodoroConfig = {
   longMin: 20,
   longEvery: 4,
   strictMode: true,
+  enableTask: false,
+  showFloatingTimer: true,
+  enableBreakNotifications: true,
 };
 
 export const STORAGE_KEY = "pomodoroState" as const;

--- a/apps/browser-extension/src/popup.tsx
+++ b/apps/browser-extension/src/popup.tsx
@@ -15,6 +15,7 @@ function IndexPopup() {
         <PomodoroSettings
           isOpen={showSettings}
           onClose={() => setShowSettings(false)}
+          showTaskSetting={false}
         />
       ) : (
         <PomodoroHome onOpenSettings={() => setShowSettings(true)} />

--- a/apps/browser-extension/src/tabs/debug.tsx
+++ b/apps/browser-extension/src/tabs/debug.tsx
@@ -4,25 +4,141 @@ import { useState } from 'react';
 import { Toaster } from 'sonner';
 import { PomodoroHome } from '../components/pomodoro/PomodoroHome';
 import { PomodoroSettings } from '../components/pomodoro/PomodoroSettings';
+import { usePomodoro } from '../hooks/pomodoro/usePomodoro';
 
 function DebugTab() {
   const [showSettings, setShowSettings] = useState(false);
+  const { state } = usePomodoro();
+
+  const renderDebugValue = (value: any): string => {
+    if (value === null || value === undefined) {
+      return 'null';
+    }
+    if (typeof value === 'boolean') {
+      return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+      return value.toString();
+    }
+    if (typeof value === 'string') {
+      return `"${value}"`;
+    }
+    return JSON.stringify(value);
+  };
 
   return (
-    <div className="dark relative flex h-[600px] w-[380px] flex-col overflow-hidden overscroll-none bg-background text-foreground mx-auto mt-8 border rounded-lg shadow-lg">
-      <div className="absolute top-2 right-2 text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
-        Debug Mode
-      </div>
+    <div className="dark flex h-screen w-full bg-background text-foreground">
       <Toaster />
-      {showSettings ? (
-        <PomodoroSettings
-          isOpen={showSettings}
-          onClose={() => setShowSettings(false)}
-        />
-      ) : (
-        <PomodoroHome onOpenSettings={() => setShowSettings(true)} />
-      )}
-     
+      
+      {/* Left Panel - Pomodoro Interface */}
+      <div className="relative flex h-[600px] w-[380px] flex-col overflow-hidden overscroll-none bg-background text-foreground mt-8 ml-8 border rounded-lg shadow-lg">
+        <div className="absolute top-2 right-2 text-xs text-muted-foreground bg-muted px-2 py-1 rounded">
+          Debug Mode
+        </div>
+        {showSettings ? (
+          <PomodoroSettings
+            isOpen={showSettings}
+            onClose={() => setShowSettings(false)}
+            showTaskSetting={true}
+          />
+        ) : (
+          <PomodoroHome onOpenSettings={() => setShowSettings(true)} />
+        )}
+      </div>
+
+      {/* Right Panel - Debug Info */}
+      <div className="flex-1 p-8">
+        <div className="h-full border rounded-lg bg-muted/20 p-4 overflow-y-auto">
+          <h2 className="text-lg font-semibold mb-4 text-primary">Debug Information</h2>
+          
+          {state ? (
+            <div className="space-y-4 font-mono text-sm">
+              
+              {/* PomodoroConfig Section */}
+              <div className="bg-muted/30 p-3 rounded">
+                <h3 className="font-semibold text-primary mb-2">config:</h3>
+                <div className="pl-4 space-y-1">
+                  {state.config && Object.entries(state.config).map(([key, value]) => (
+                    <div key={key} className="flex">
+                      <span className="text-blue-400 min-w-[140px]">{key}:</span>
+                      <span className="text-green-400">{renderDebugValue(value)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* PomodoroState Section */}
+              <div className="bg-muted/30 p-3 rounded">
+                <h3 className="font-semibold text-primary mb-2">state:</h3>
+                <div className="pl-4 space-y-1">
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">phase:</span>
+                    <span className="text-green-400">{renderDebugValue(state.phase)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">running:</span>
+                    <span className="text-green-400">{renderDebugValue(state.running)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">paused:</span>
+                    <span className="text-green-400">{renderDebugValue(state.paused)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">cycleCount:</span>
+                    <span className="text-green-400">{renderDebugValue(state.cycleCount)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">startedAt:</span>
+                    <span className="text-green-400">{renderDebugValue(state.startedAt)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">endsAt:</span>
+                    <span className="text-green-400">{renderDebugValue(state.endsAt)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">pausedAt:</span>
+                    <span className="text-green-400">{renderDebugValue(state.pausedAt)}</span>
+                  </div>
+                  <div className="flex">
+                    <span className="text-blue-400 min-w-[140px]">pauseAccumMs:</span>
+                    <span className="text-green-400">{renderDebugValue(state.pauseAccumMs)}</span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Timestamps Section */}
+              {(state.startedAt || state.endsAt || state.pausedAt) && (
+                <div className="bg-muted/30 p-3 rounded">
+                  <h3 className="font-semibold text-primary mb-2">timestamps (formatted):</h3>
+                  <div className="pl-4 space-y-1">
+                    {state.startedAt && (
+                      <div className="flex">
+                        <span className="text-blue-400 min-w-[140px]">startedAt:</span>
+                        <span className="text-yellow-400">{new Date(state.startedAt).toLocaleString()}</span>
+                      </div>
+                    )}
+                    {state.endsAt && (
+                      <div className="flex">
+                        <span className="text-blue-400 min-w-[140px]">endsAt:</span>
+                        <span className="text-yellow-400">{new Date(state.endsAt).toLocaleString()}</span>
+                      </div>
+                    )}
+                    {state.pausedAt && (
+                      <div className="flex">
+                        <span className="text-blue-400 min-w-[140px]">pausedAt:</span>
+                        <span className="text-yellow-400">{new Date(state.pausedAt).toLocaleString()}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+            </div>
+          ) : (
+            <div className="text-muted-foreground">Loading state...</div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Add three new PomodoroConfig properties:
  * enableTask: optional task mode for pomodoro sessions (default: false)
  * showFloatingTimer: floating timer display in web pages (default: true)
  * enableBreakNotifications: break reminder notifications (default: true)

- Redesign PomodoroSettings component with organized sections:
  * General Features: task mode toggle (hidden in popup, shown in debug)
  * Display Options: floating timer and break notifications
  * Break Behavior: existing strict mode settings

- Add comprehensive internationalization support for EN/ZH/JA
- Enhance debug.tsx with split-panel layout showing real-time state inspection
- Improve popup.tsx and debug.tsx with configurable task setting visibility
- Prepare foundation for upcoming floating timer and notification features

🤖 Generated with [Claude Code](https://claude.ai/code)